### PR TITLE
[IGOWEB-1439] Handle invalid PMs in Roslin pipeline-kickoff

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import org.mskcc.util.email.EmailToMimeMessageConverter
 import org.mskcc.util.email.JavaxEmailSender
 
 group 'org.mskcc.kickoff.lims'
-version '1.24.0-SNAPSHOT'
+version '1.24.1-SNAPSHOT'
 
 apply plugin: 'application'
 apply plugin: 'maven'

--- a/src/integration-test/java/org/mskcc/kickoff/fast/endtoend/FromJiraPmJiraUserRetrieverTest.java
+++ b/src/integration-test/java/org/mskcc/kickoff/fast/endtoend/FromJiraPmJiraUserRetrieverTest.java
@@ -25,8 +25,6 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-// only do retrieve jira pm user
-// will not do any put or post via jira api
 @RunWith(SpringJUnit4ClassRunner.class)
 @ActiveProfiles({"test", "tango"})
 @ContextConfiguration(classes = FromJiraPmJiraUserRetrieverTestConfig.class)
@@ -47,7 +45,7 @@ public class FromJiraPmJiraUserRetrieverTest {
     @Value("${jira.rest.path}")
     private String jiraRestPath;
 
-    // will need change later is PM left or removed from PM group user at jira
+    // will need change later if PM left or removed from PM group at jira
     private String currentValidIgoName = "Bourque, Caitlin";
 
     @Lazy

--- a/src/integration-test/java/org/mskcc/kickoff/fast/endtoend/FromJiraPmJiraUserRetrieverTest.java
+++ b/src/integration-test/java/org/mskcc/kickoff/fast/endtoend/FromJiraPmJiraUserRetrieverTest.java
@@ -1,0 +1,106 @@
+package org.mskcc.kickoff.fast.endtoend;
+
+import org.apache.commons.codec.binary.Base64;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mskcc.kickoff.upload.jira.PmJiraUserRetriever;
+import org.mskcc.kickoff.upload.jira.domain.JiraGroup;
+import org.mskcc.kickoff.upload.jira.domain.JiraUser;
+import org.mskcc.kickoff.util.Constants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+// only do retrieve jira pm user
+// will not do any put or post via jira api
+@RunWith(SpringJUnit4ClassRunner.class)
+@ActiveProfiles({"test", "tango"})
+@ContextConfiguration(classes = FromJiraPmJiraUserRetrieverTestConfig.class)
+public class FromJiraPmJiraUserRetrieverTest {
+
+    @Value("${jira.username}")
+    private String jiraUsername;
+
+    @Value("${jira.password}")
+    private String jiraPassword;
+
+    @Value("${jira.url}")
+    private String jiraUrl;
+
+    @Value("${jira.pm.group.name}")
+    private String pmGroupName;
+
+    @Value("${jira.rest.path}")
+    private String jiraRestPath;
+
+    // will need change later is PM left or removed from PM group user at jira
+    private String currentValidIgoName = "Bourque, Caitlin";
+
+    @Lazy
+    @Autowired
+    private PmJiraUserRetriever pmJiraUserRetriever;
+
+    @Before
+    public void setup() {
+        FromJiraPmJiraUserRetrieverTestConfig.setJiraPassword(jiraPassword);
+        FromJiraPmJiraUserRetrieverTestConfig.setJiraUsername(jiraUsername);
+    }
+
+    @Test
+    public void whenPMangerNameIsValid_shouldReturnMatchedJiraUser() {
+        JiraUser assignee = pmJiraUserRetriever.retrieve(currentValidIgoName);
+        assertThat(assignee.getKey(), is("bourquec"));
+    }
+
+    @Test
+    public void whenNO_PM_shouldReturnMatchedFirstJiraGroupMember() {
+        JiraUser assignee = pmJiraUserRetriever.retrieve(Constants.NO_PM);
+        List<JiraUser> jiraPmUsers = getPmJiraUsers();
+        assertThat(assignee.getKey(), is(jiraPmUsers.get(0).getKey()));
+    }
+
+    @Test
+    public void whenPMangerNameIsNotFound_shouldReturnMatchedFirstJiraGroupMember() {
+        JiraUser assignee = pmJiraUserRetriever.retrieve("Liu, Feng");
+        List<JiraUser> jiraPmUsers = getPmJiraUsers();
+        assertThat(assignee.getKey(), is(jiraPmUsers.get(0).getKey()));
+    }
+
+    private List<JiraUser> getPmJiraUsers() {
+        String getAllPmUsersUrl = String.format("%s/%s/group/member?groupname=%s", jiraUrl, jiraRestPath,
+                pmGroupName);
+        System.out.println(getAllPmUsersUrl);
+
+        HttpEntity<String> request = getHttpHeaders();
+        ResponseEntity<JiraGroup> response = new RestTemplate().exchange(getAllPmUsersUrl, HttpMethod.GET, request,
+                JiraGroup.class);
+        List<JiraUser> users = response.getBody().getValues();
+        System.out.println(String.format("Found %s users in group %s:", users.size(), pmGroupName));
+        return users;
+    }
+
+    private HttpEntity<String> getHttpHeaders() {
+        String plainCreds = String.format("%s:%s", jiraUsername, jiraPassword);
+        byte[] plainCredsBytes = plainCreds.getBytes();
+        byte[] base64CredsBytes = Base64.encodeBase64(plainCredsBytes);
+        String base64Creds = new String(base64CredsBytes);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Basic " + base64Creds);
+        return new HttpEntity<>(headers);
+    }
+
+}

--- a/src/integration-test/java/org/mskcc/kickoff/fast/endtoend/FromJiraPmJiraUserRetrieverTestConfig.java
+++ b/src/integration-test/java/org/mskcc/kickoff/fast/endtoend/FromJiraPmJiraUserRetrieverTestConfig.java
@@ -1,0 +1,63 @@
+package org.mskcc.kickoff.fast.endtoend;
+
+import org.mskcc.kickoff.upload.jira.FromJiraPmJiraUserRetriever;
+import org.mskcc.kickoff.upload.jira.PmJiraUserRetriever;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.InterceptingClientHttpRequestFactory;
+import org.springframework.http.client.support.BasicAuthorizationInterceptor;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+@Configuration
+public class FromJiraPmJiraUserRetrieverTestConfig {
+    private static String jiraUsername;
+    private static String jiraPassword;
+
+    @Bean
+    @Order(value = 0)
+    PropertyPlaceholderConfigurer propertyPlaceholderConfigurer() throws IOException {
+        final PropertyPlaceholderConfigurer configurer = new PropertyPlaceholderConfigurer();
+  configurer.setLocations(new PathMatchingResourcePatternResolver().getResources("classpath*:application-dev.properties"));
+        return configurer;
+    }
+
+    @Bean
+    @Qualifier("jiraRestTemplate")
+    @Lazy
+    public RestTemplate jiraRestTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+        addBasicAuth(restTemplate, jiraUsername, jiraPassword);
+        return restTemplate;
+    }
+
+    void addBasicAuth(RestTemplate restTemplate, String username, String password) {
+        List<ClientHttpRequestInterceptor> interceptors = Collections.singletonList(new BasicAuthorizationInterceptor
+                (username, password));
+        restTemplate.setRequestFactory(new InterceptingClientHttpRequestFactory(restTemplate.getRequestFactory(),
+                interceptors));
+    }
+
+    @Bean
+    @Lazy
+    PmJiraUserRetriever pmJiraUserRetriever () {
+        return new FromJiraPmJiraUserRetriever(jiraRestTemplate());
+    }
+
+    public static void setJiraUsername(String jiraUsername) {
+        FromJiraPmJiraUserRetrieverTestConfig.jiraUsername = jiraUsername;
+    }
+
+    public static void setJiraPassword(String jiraPassword) {
+        FromJiraPmJiraUserRetrieverTestConfig.jiraPassword = jiraPassword;
+    }
+}

--- a/src/main/java/org/mskcc/kickoff/upload/jira/FromJiraPmJiraUserRetriever.java
+++ b/src/main/java/org/mskcc/kickoff/upload/jira/FromJiraPmJiraUserRetriever.java
@@ -1,5 +1,6 @@
 package org.mskcc.kickoff.upload.jira;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.mskcc.kickoff.upload.jira.domain.JiraGroup;
 import org.mskcc.kickoff.upload.jira.domain.JiraUser;
@@ -17,6 +18,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @Component
 @Profile(Constants.PROD_PROFILE)
@@ -50,36 +52,54 @@ public class FromJiraPmJiraUserRetriever implements PmJiraUserRetriever {
 
     @Override
     public JiraUser retrieve(String projectManagerIgoName) {
-        projectManagerIgoName = getPmIgoName(projectManagerIgoName);
+        LOGGER.info(String.format("Looking for jira user with IGO name [%s]", projectManagerIgoName));
 
-        LOGGER.info(String.format("Looking for jira user with IGO name \"%s\"", projectManagerIgoName));
-
+        // fetch jira users of pm group
         List<JiraUser> pmJiraUsers = getPmJiraUsers();
+
+        // check if projectManagerIgoName is valid
+        // if valid, then try to match
+        if (isProjectManagerIgoNameValid(projectManagerIgoName)) {
+            Optional<JiraUser> matchedJiraUsers = tryMatchJiraUsers(projectManagerIgoName, pmJiraUsers);
+            if (matchedJiraUsers.isPresent()) return matchedJiraUsers.get();
+        }
+
+        // if not valid or matching failed, use first member
+        if (pmJiraUsers.isEmpty()) {
+            throw new NoPmFoundException(String.format("No Project Manager found in jira group [%s].", pmGroupName));
+        } else {
+            LOGGER.info(String.format("No Project Manager in jira group %s " +
+                    "with IGO name %s: use first member of igo-pm group.", pmGroupName, projectManagerIgoName));
+            // No matching found
+            // set the assignee to the first member of "igo-pm" jira group as returned by the Jira API
+            return pmJiraUsers.get(0);
+        }
+    }
+
+    // invalid cases: null, empty, blank, NA, NO_PM
+    private boolean isProjectManagerIgoNameValid(String projectManagerIgoName) {
+        if (StringUtils.isNotBlank(projectManagerIgoName)
+                && !Constants.NO_PM.equalsIgnoreCase(projectManagerIgoName)
+                && !Constants.NA.equals(projectManagerIgoName)){
+            return true;
+        }
+        LOGGER.warn(String.format("Invalid Project manager in LIMS: [%s].", projectManagerIgoName));
+        return false;
+    }
+
+    private Optional<JiraUser> tryMatchJiraUsers(String projectManagerIgoName, List<JiraUser> pmJiraUsers) {
         for (JiraUser pmJiraUser : pmJiraUsers) {
             if (userHasProperty(pmJiraUser, igoFormattedNameProperty)) {
                 String igoFormattedName = getIgoFormattedName(pmJiraUser);
                 if (Objects.equals(igoFormattedName, projectManagerIgoName)) {
                     LOGGER.info(String.format("Project Manager jira user found %s for IGO formatted name %s",
                             pmJiraUser, projectManagerIgoName));
-                    return pmJiraUser;
+                    return Optional.of(pmJiraUser);
                 }
             }
         }
 
-        throw new NoPmFoundException(String.format("There is no Project Manager in jira group %s " +
-                        "with IGO name %s",
-                pmGroupName, projectManagerIgoName));
-    }
-
-    private String getPmIgoName(String projectManagerIgoName) {
-        if (Constants.NO_PM.equals(projectManagerIgoName)) {
-            LOGGER.warn(String.format("Project manager in LIMS is set to %s. Default PM will be used instead: %s",
-                    Constants.NO_PM, defaultPm));
-
-            projectManagerIgoName = defaultPm;
-        }
-
-        return projectManagerIgoName;
+        return Optional.empty();
     }
 
     private boolean userHasProperty(JiraUser pmJiraUser, String igoFormattedNameProperty) {

--- a/src/main/java/org/mskcc/kickoff/upload/jira/FromJiraPmJiraUserRetriever.java
+++ b/src/main/java/org/mskcc/kickoff/upload/jira/FromJiraPmJiraUserRetriever.java
@@ -43,8 +43,8 @@ public class FromJiraPmJiraUserRetriever implements PmJiraUserRetriever {
     @Value("${jira.rest.path}")
     private String jiraRestPath;
 
-    @Value("${default.pm}")
-    private String defaultPm;
+//    @Value("${default.pm}")
+//    private String defaultPm;
 
     private RestTemplate restTemplate;
 

--- a/src/main/java/org/mskcc/kickoff/upload/jira/FromJiraPmJiraUserRetriever.java
+++ b/src/main/java/org/mskcc/kickoff/upload/jira/FromJiraPmJiraUserRetriever.java
@@ -46,9 +46,11 @@ public class FromJiraPmJiraUserRetriever implements PmJiraUserRetriever {
     @Value("${default.pm}")
     private String defaultPm;
 
-    @Autowired
-    @Qualifier("jiraRestTemplate")
     private RestTemplate restTemplate;
+
+    public FromJiraPmJiraUserRetriever(@Qualifier("jiraRestTemplate") RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
 
     @Override
     public JiraUser retrieve(String projectManagerIgoName) {


### PR DESCRIPTION
* Logic for `retrieve` Jira user in `FromJiraPmJiraUserRetriever`, as improvement upon PR #50: 
  * `Project Manager` fetched from LIMS is defined to be invalid if its value is `NA`, `NO PM`, blank, empty or `null`. 
  * In case of invalid `Project Manager` or no matching with igo user, assignee is set to the first member of `igo-pm` jira group returned by the Jira API. 
  * In case of no `igo-pm` members available, exception will be thrown. 
* `default.pm` entry remains in application property file, but I think is not being used anymore, may need to be removed. 
* `application-dev.properties`: `jira.pm.group.name` shall be `igo-pm`, NOT `igo_pm`.