### PR TITLE
[IGOWEB-1513] remove deliverto entry from request file

### DIFF
--- a/src/integration-test/resources/integrationtest.properties
+++ b/src/integration-test/resources/integrationtest.properties
@@ -2,3 +2,4 @@ test.integration.manifestOutputFilePath=integration-test/manifests
 test.integration.manifestArchivePath=integration-test/archive
 test.integration.manifestGoldenFilePath=/home/feng/dev/manifests
 test.integration.projectIds=04430_AI,06302_D,05971_S
+test.integration.fastq_path=/ifs/archive/GCL

--- a/src/main/java/org/mskcc/kickoff/lims/ProjectInfoRetriever.java
+++ b/src/main/java/org/mskcc/kickoff/lims/ProjectInfoRetriever.java
@@ -71,7 +71,6 @@ public class ProjectInfoRetriever {
                     Constants.ProjectInfo.REQUESTOR,
                     Constants.ProjectInfo.REQUESTOR_E_MAIL,
                     Constants.ProjectInfo.PLATFORM,
-                    Constants.ProjectInfo.ALTERNATE_EMAILS,
                     Constants.ProjectInfo.IGO_PROJECT_ID,
                     Constants.ProjectInfo.FINAL_PROJECT_TITLE,
                     Constants.ProjectInfo.CMO_PROJECT_ID,
@@ -172,33 +171,6 @@ public class ProjectInfoRetriever {
                     projectInfo.put(Constants.ProjectInfo.REQUESTOR, RequesterName[1] + ", " + RequesterName[0]);
                 }
                 projectInfo.put(Constants.ProjectInfo.REQUESTOR_E_MAIL, InvestigatorEmail);
-
-                // Get the Child e-mail records, if there are any
-                List<DataRecord> emailList = Arrays.asList(requestDataRecord.getChildrenOfType(VeloxConstants.EMAIL, apiUser));
-                if (emailList.size() > 0) {
-                    List<String> allELists = new LinkedList<>();
-                    for (DataRecord email : emailList) {
-                        // Grab main email
-                        String email_to_add = email.getStringVal(VeloxConstants.EMAIL, apiUser).toLowerCase();
-                        if (!email_to_add.equals(LabHeadEmail) &&
-                                !email_to_add.equals(InvestigatorEmail) &&
-                                !allELists.contains(email_to_add) && email_to_add.length() != 0) {
-                            allELists.add(email_to_add);
-                        }
-                        // Grab AlternateEmail
-                        email_to_add = email.getStringVal("AlternateEmail", apiUser).toLowerCase();
-                        if (!email_to_add.equals(LabHeadEmail) &&
-                                !email_to_add.equals(InvestigatorEmail) &&
-                                !allELists.contains(email_to_add) && email_to_add.length() != 0) {
-                            allELists.add(email_to_add);
-                        }
-
-                    }
-                    if (allELists.size() > 0) {
-                        String AlternateEmails = StringUtils.join(allELists, ",");
-                        projectInfo.put(Constants.ProjectInfo.ALTERNATE_EMAILS, AlternateEmails);
-                    }
-                }
             }
 
             return getTransformedProjectInfo(projectInfo);

--- a/src/main/java/org/mskcc/kickoff/printer/RequestFilePrinter.java
+++ b/src/main/java/org/mskcc/kickoff/printer/RequestFilePrinter.java
@@ -32,7 +32,7 @@ import static org.mskcc.kickoff.util.Utils.getJoinedCollection;
 public class RequestFilePrinter extends FilePrinter {
     private static final Logger PM_LOGGER = Logger.getLogger(Constants.PM_LOGGER);
     private static final Logger DEV_LOGGER = Logger.getLogger(Constants.DEV_LOGGER);
-    private final String manualMappingPinfoToRequestFile = "Alternate_E-mails:DeliverTo,Lab_Head:PI_Name," +
+    private final String manualMappingPinfoToRequestFile = "Lab_Head:PI_Name," +
             "Lab_Head_E-mail:PI,Requestor:Investigator_Name,Requestor_E-mail:Investigator,CMO_Project_ID:ProjectName," +
             "Final_Project_Title:ProjectTitle,CMO_Project_Brief:ProjectDesc";
     private final Set<String> requiredProjectInfoFields = new HashSet<>();

--- a/src/main/java/org/mskcc/kickoff/sampleset/SampleSetProjectInfoConverter.java
+++ b/src/main/java/org/mskcc/kickoff/sampleset/SampleSetProjectInfoConverter.java
@@ -24,7 +24,6 @@ public class SampleSetProjectInfoConverter {
         projectInfo.put(ProjectInfo.REQUESTOR, getRequestor(sampleSet));
         projectInfo.put(ProjectInfo.REQUESTOR_E_MAIL, getRequestorEmail(sampleSet));
         projectInfo.put(ProjectInfo.PLATFORM, getPlatform(sampleSet));
-        projectInfo.put(ProjectInfo.ALTERNATE_EMAILS, getAlternateEmails(sampleSet));
         projectInfo.put(ProjectInfo.IGO_PROJECT_ID, getIgoProjectId(sampleSet));
         projectInfo.put(ProjectInfo.FINAL_PROJECT_TITLE, getFinalProjectTitle(sampleSet));
         projectInfo.put(ProjectInfo.CMO_PROJECT_ID, getCmoProjectId(sampleSet));

--- a/src/main/java/org/mskcc/kickoff/sampleset/SampleSetProjectInfoConverter.java
+++ b/src/main/java/org/mskcc/kickoff/sampleset/SampleSetProjectInfoConverter.java
@@ -72,10 +72,6 @@ public class SampleSetProjectInfoConverter {
         return sampleSet.getBaitSet();
     }
 
-    private String getAlternateEmails(KickoffSampleSet sampleSet) {
-        return getPropertyFromPrimaryRequest(sampleSet, ProjectInfo.ALTERNATE_EMAILS);
-    }
-
     private String getIgoProjectId(KickoffSampleSet sampleSet) {
         return sampleSet.getName();
     }

--- a/src/test/java/org/mskcc/kickoff/converter/SampleSetProjectInfoConverterTest.java
+++ b/src/test/java/org/mskcc/kickoff/converter/SampleSetProjectInfoConverterTest.java
@@ -53,11 +53,6 @@ public class SampleSetProjectInfoConverterTest {
     }
 
     @Test
-    public void whenConvertingProjectInfo_shouldAssignAlternateEmailsFromPrimeRequest() {
-        assertPropertyIsResolvedFromPrimeRequest(Constants.ProjectInfo.ALTERNATE_EMAILS);
-    }
-
-    @Test
     public void whenPrimaryRequestHasNoFinalProjectTitle_shouldThrowAnException() {
         assertExceptionThrownOnMissingPrimaryRequestProperty(Constants.ProjectInfo.FINAL_PROJECT_TITLE);
     }
@@ -330,7 +325,6 @@ public class SampleSetProjectInfoConverterTest {
         kickoffRequest.addProjectProperty(Constants.ProjectInfo.TUMOR_TYPE, "tumorType");
         kickoffRequest.addProjectProperty(Constants.ProjectInfo.REQUESTOR, "requestor");
         kickoffRequest.addProjectProperty(Constants.ProjectInfo.REQUESTOR_E_MAIL, "requestor@example.com");
-        kickoffRequest.addProjectProperty(Constants.ProjectInfo.ALTERNATE_EMAILS, "some@example.com");
         kickoffRequest.addProjectProperty(Constants.ProjectInfo.DATA_ANALYST, "Some Analyst");
         kickoffRequest.addProjectProperty(Constants.ProjectInfo.DATA_ANALYST_EMAIL, "analust@example.com");
 


### PR DESCRIPTION
- Logic related to `DeliverTo` entry in request file (as `Alternate_E-mails` in `ProjectInfo`) was removed. 
- API user in production has access right to `limsuser` table